### PR TITLE
Exclude the Visual Studio solution cache folder '.vs'

### DIFF
--- a/PsISEProjectExplorer/Services/FilesPatternProvider.cs
+++ b/PsISEProjectExplorer/Services/FilesPatternProvider.cs
@@ -14,7 +14,7 @@ namespace PsISEProjectExplorer.Services
 
         private static readonly Regex PowershellModulesRegex = new Regex(@".*\.ps(d|m)1$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex ExcludeRegex = new Regex(@"\\(\.git|\.svn)($|\\)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ExcludeRegex = new Regex(@"\\(\.git|\.svn|\.vs)($|\\)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public bool IncludeAllFiles { get; set; }
 


### PR DESCRIPTION
Exclude the .vs folder from the Project Explorer, because this is just a
cache folder like the .git or .svn folders are.